### PR TITLE
Fix: Require `render` modifier for inline examples

### DIFF
--- a/examples/basic/src/components/Button/Button.js
+++ b/examples/basic/src/components/Button/Button.js
@@ -7,11 +7,16 @@ import './Button.css';
  * The only true button.
  *
  * @example Inline Example 1:
- * ```jsx
+ * ```jsx render
  * <Button>I Dare you</Button>
  * ```
  *
  * @example Inline Example 2:
+ * ```jsx render
+ * <Button>Pretty please.</Button>
+ * ```
+ *
+ * @example Invalid Example 2:
  * ```jsx
  * <Button>Pretty please.</Button>
  * ```

--- a/loaders/__tests__/props-loader.spec.js
+++ b/loaders/__tests__/props-loader.spec.js
@@ -162,6 +162,44 @@ it('should attach examples from Markdown file', () => {
 	);
 });
 
+it('should attach inline examples', () => {
+	const file = './test/components/ButtonInline/ButtonInline.js';
+	const result = propsLoader.call(
+		{
+			request: file,
+			_styleguidist,
+		},
+		readFileSync(file, 'utf8')
+	);
+	expect(result).toBeTruthy();
+
+	expect(() => new vm.Script(result)).not.toThrow();
+	// Result spits out JS text which exports an array with two objects, one
+	// with "type" markdown and the other other with "type" code. We want to
+	// verify this.
+	expect(result).toMatch(/'type':\s'markdown'[\S\s]+'type':\s'code'/);
+});
+
+it('should attach doclet examples with inline examples', () => {
+	const file = './test/components/ButtonInline/ButtonInline.js';
+	const result = propsLoader.call(
+		{
+			request: file,
+			_styleguidist,
+		},
+		readFileSync(file, 'utf8')
+	);
+	expect(result).toBeTruthy();
+
+	expect(() => new vm.Script(result)).not.toThrow();
+	// Result spits out JS text which exports an array with two objects, one
+	// with "type" markdown and the other other with "type" code. We want to
+	// verify this.
+	expect(result).toMatch(/'type':\s'markdown'[\S\s]+'type':\s'code'/);
+	// Also verify that we are still requiring an example file normally
+	expect(result).toMatch(/require\('!!.*?\/loaders\/examples-loader\.js!\.\/button.example.md'\)/);
+});
+
 it('should warn if no componets are exported', () => {
 	const warn = jest.fn();
 	logger.once('warn', warn);

--- a/loaders/props-loader.js
+++ b/loaders/props-loader.js
@@ -76,8 +76,6 @@ module.exports = function(source) {
 			let appendAst;
 			if (typeof example === 'string') {
 				appendAst = inlineLoader(this, examplesLoader, example);
-			} else {
-				appendAst = generate(toAst(example));
 			}
 			inlineExampleBlock += `docs.examples = docs.examples.concat(${appendAst});\n`;
 		});

--- a/loaders/utils/__tests__/__snapshots__/getProps.spec.js.snap
+++ b/loaders/utils/__tests__/__snapshots__/getProps.spec.js.snap
@@ -168,22 +168,24 @@ Object {
 
 exports[`should not return inline example when inline code without a render modifier is provided 1`] = `
 Object {
-  "description": "    		The only true button.
-    		@example Inline Example:
-    		\`\`\`jsx
-    		&lt;Button&gt;I Dare you&lt;/Button&gt;
-    		\`\`\`
+  "description": "The only true button.
 ",
   "displayName": "Button",
-  "doclets": Object {},
+  "doclets": Object {
+    "example": "Inline Example:
+\`\`\`jsx
+<Button>I Dare you</Button>
+\`\`\`",
+  },
+  "examples": Array [],
   "methods": Array [],
   "tags": Object {
     "example": Array [
       Object {
         "description": "Inline Example:
-			\`\`\`jsx
-			<Button>I Dare you</Button>
-			\`\`\`",
+\`\`\`jsx
+<Button>I Dare you</Button>
+\`\`\`",
         "title": "example",
       },
     ],
@@ -283,22 +285,24 @@ Object {
 
 exports[`should return inline example when inline code with a render modifier is provided 1`] = `
 Object {
-  "description": "    		The only true button.
-    		@example Inline Example:
-    		\`\`\`jsx render
-    		&lt;Button&gt;I Dare you&lt;/Button&gt;
-    		\`\`\`
+  "description": "The only true button.
 ",
   "displayName": "Button",
   "doclets": Object {},
+  "examples": Array [
+    "Inline Example:
+\`\`\`jsx render
+<Button>I Dare you</Button>
+\`\`\`",
+  ],
   "methods": Array [],
   "tags": Object {
     "example": Array [
       Object {
         "description": "Inline Example:
-			\`\`\`jsx render
-			<Button>I Dare you</Button>
-			\`\`\`",
+\`\`\`jsx render
+<Button>I Dare you</Button>
+\`\`\`",
         "title": "example",
       },
     ],

--- a/loaders/utils/__tests__/__snapshots__/getProps.spec.js.snap
+++ b/loaders/utils/__tests__/__snapshots__/getProps.spec.js.snap
@@ -166,6 +166,31 @@ Object {
 }
 `;
 
+exports[`should not return inline example when inline code without a render modifier is provided 1`] = `
+Object {
+  "description": "    		The only true button.
+    		@example Inline Example:
+    		\`\`\`jsx
+    		&lt;Button&gt;I Dare you&lt;/Button&gt;
+    		\`\`\`
+",
+  "displayName": "Button",
+  "doclets": Object {},
+  "methods": Array [],
+  "tags": Object {
+    "example": Array [
+      Object {
+        "description": "Inline Example:
+			\`\`\`jsx
+			<Button>I Dare you</Button>
+			\`\`\`",
+        "title": "example",
+      },
+    ],
+  },
+}
+`;
+
 exports[`should remove non-public methods 1`] = `
 Object {
   "displayName": "Button",
@@ -252,6 +277,31 @@ Object {
       "tags": Object {},
       "type": Object {},
     },
+  },
+}
+`;
+
+exports[`should return inline example when inline code with a render modifier is provided 1`] = `
+Object {
+  "description": "    		The only true button.
+    		@example Inline Example:
+    		\`\`\`jsx render
+    		&lt;Button&gt;I Dare you&lt;/Button&gt;
+    		\`\`\`
+",
+  "displayName": "Button",
+  "doclets": Object {},
+  "methods": Array [],
+  "tags": Object {
+    "example": Array [
+      Object {
+        "description": "Inline Example:
+			\`\`\`jsx render
+			<Button>I Dare you</Button>
+			\`\`\`",
+        "title": "example",
+      },
+    ],
   },
 }
 `;

--- a/loaders/utils/__tests__/__snapshots__/getSections.spec.js.snap
+++ b/loaders/utils/__tests__/__snapshots__/getSections.spec.js.snap
@@ -47,6 +47,19 @@ Array [
         "slug": "button-2",
       },
       Object {
+        "filepath": "components/ButtonInline/ButtonInline.js",
+        "hasExamples": true,
+        "metadata": Object {},
+        "module": Object {
+          "require": "~/test/components/ButtonInline/ButtonInline.js",
+        },
+        "pathLine": "components/ButtonInline/ButtonInline.js",
+        "props": Object {
+          "require": "!!~/loaders/props-loader.js!~/test/components/ButtonInline/ButtonInline.js",
+        },
+        "slug": "buttoninline-2",
+      },
+      Object {
         "filepath": "components/Placeholder/Placeholder.js",
         "hasExamples": true,
         "metadata": Object {
@@ -114,6 +127,19 @@ Array [
           "require": "!!~/loaders/props-loader.js!~/test/components/Button/Button.js",
         },
         "slug": "button-3",
+      },
+      Object {
+        "filepath": "components/ButtonInline/ButtonInline.js",
+        "hasExamples": true,
+        "metadata": Object {},
+        "module": Object {
+          "require": "~/test/components/ButtonInline/ButtonInline.js",
+        },
+        "pathLine": "components/ButtonInline/ButtonInline.js",
+        "props": Object {
+          "require": "!!~/loaders/props-loader.js!~/test/components/ButtonInline/ButtonInline.js",
+        },
+        "slug": "buttoninline-3",
       },
       Object {
         "filepath": "components/Placeholder/Placeholder.js",
@@ -200,6 +226,19 @@ Object {
         "require": "!!~/loaders/props-loader.js!~/test/components/Button/Button.js",
       },
       "slug": "button",
+    },
+    Object {
+      "filepath": "components/ButtonInline/ButtonInline.js",
+      "hasExamples": true,
+      "metadata": Object {},
+      "module": Object {
+        "require": "~/test/components/ButtonInline/ButtonInline.js",
+      },
+      "pathLine": "components/ButtonInline/ButtonInline.js",
+      "props": Object {
+        "require": "!!~/loaders/props-loader.js!~/test/components/ButtonInline/ButtonInline.js",
+      },
+      "slug": "buttoninline",
     },
     Object {
       "filepath": "components/Placeholder/Placeholder.js",
@@ -291,6 +330,19 @@ Object {
         "require": "!!~/loaders/props-loader.js!~/test/components/Button/Button.js",
       },
       "slug": "button-1",
+    },
+    Object {
+      "filepath": "components/ButtonInline/ButtonInline.js",
+      "hasExamples": true,
+      "metadata": Object {},
+      "module": Object {
+        "require": "~/test/components/ButtonInline/ButtonInline.js",
+      },
+      "pathLine": "components/ButtonInline/ButtonInline.js",
+      "props": Object {
+        "require": "!!~/loaders/props-loader.js!~/test/components/ButtonInline/ButtonInline.js",
+      },
+      "slug": "buttoninline-1",
     },
     Object {
       "filepath": "components/Placeholder/Placeholder.js",

--- a/loaders/utils/__tests__/getComponentFiles.spec.js
+++ b/loaders/utils/__tests__/getComponentFiles.spec.js
@@ -58,6 +58,7 @@ it('getComponentFiles() should accept components as a glob', () => {
 	expect(deabs(result)).toEqual([
 		'~/components/Annotation/Annotation.js',
 		'~/components/Button/Button.js',
+		'~/components/ButtonInline/ButtonInline.js',
 		'~/components/Placeholder/Placeholder.js',
 		'~/components/Price/Price.js',
 		'~/components/RandomButton/RandomButton.js',

--- a/loaders/utils/__tests__/getComponentFilesFromSections.spec.js
+++ b/loaders/utils/__tests__/getComponentFilesFromSections.spec.js
@@ -29,6 +29,7 @@ it('getComponentFilesFromSections() should return a list of files', () => {
 	const result = getComponentFilesFromSections(sections, configDir);
 	expect(deabs(result)).toEqual([
 		'~/components/Button/Button.js',
+		'~/components/ButtonInline/ButtonInline.js',
 		'~/components/Placeholder/Placeholder.js',
 		'~/components/Price/Price.js',
 	]);

--- a/loaders/utils/__tests__/getProps.spec.js
+++ b/loaders/utils/__tests__/getProps.spec.js
@@ -193,11 +193,11 @@ it('should return inline example when inline code with a render modifier is prov
 		{
 			displayName: 'Button',
 			description: `
-			The only true button.
-			@example Inline Example:
-			\`\`\`jsx render
-			<Button>I Dare you</Button>
-			\`\`\``,
+The only true button.
+@example Inline Example:
+\`\`\`jsx render
+<Button>I Dare you</Button>
+\`\`\``,
 		},
 		__filename
 	);
@@ -210,11 +210,11 @@ it('should not return inline example when inline code without a render modifier 
 		{
 			displayName: 'Button',
 			description: `
-			The only true button.
-			@example Inline Example:
-			\`\`\`jsx
-			<Button>I Dare you</Button>
-			\`\`\``,
+The only true button.
+@example Inline Example:
+\`\`\`jsx
+<Button>I Dare you</Button>
+\`\`\``,
 		},
 		__filename
 	);

--- a/loaders/utils/__tests__/getProps.spec.js
+++ b/loaders/utils/__tests__/getProps.spec.js
@@ -188,6 +188,40 @@ The only true button.
 	expect(result).toMatchSnapshot();
 });
 
+it('should return inline example when inline code with a render modifier is provided', () => {
+	const result = getProps(
+		{
+			displayName: 'Button',
+			description: `
+			The only true button.
+			@example Inline Example:
+			\`\`\`jsx render
+			<Button>I Dare you</Button>
+			\`\`\``,
+		},
+		__filename
+	);
+
+	expect(result).toMatchSnapshot();
+});
+
+it('should not return inline example when inline code without a render modifier is provided', () => {
+	const result = getProps(
+		{
+			displayName: 'Button',
+			description: `
+			The only true button.
+			@example Inline Example:
+			\`\`\`jsx
+			<Button>I Dare you</Button>
+			\`\`\``,
+		},
+		__filename
+	);
+
+	expect(result).toMatchSnapshot();
+});
+
 it('should highlight code in description (regular code block)', () => {
 	const result = getProps({
 		description: `

--- a/test/components/ButtonInline/ButtonInline.js
+++ b/test/components/ButtonInline/ButtonInline.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * The only true button.
+ *
+ * @example Inline Example
+ * ```jsx render
+ *   <Button color="#333" size="small">Click Me</Button>
+ * ```
+ *
+ * @example ./button.example.md
+ */
+export default function Button({ color, size, children }) {
+	const styles = {
+		color,
+		fontSize: Button.sizes[size],
+	};
+
+	return <button style={styles}>{children}</button>;
+}
+Button.propTypes = {
+	/**
+	 * Button label.
+	 */
+	children: PropTypes.string.isRequired,
+	color: PropTypes.string,
+	size: PropTypes.oneOf(['small', 'normal', 'large']),
+	/**
+	 * A prop that should not be visible in the doc.
+	 * @ignore
+	 */
+	ignoredProp: PropTypes.bool,
+};
+Button.defaultProps = {
+	color: '#333',
+	size: 'normal',
+};
+Button.sizes = {
+	small: '10px',
+	normal: '14px',
+	large: '18px',
+};

--- a/test/components/ButtonInline/button.example.md
+++ b/test/components/ButtonInline/button.example.md
@@ -1,0 +1,5 @@
+Extra example file linked via `@example` doclet:
+
+```jsx
+<Button size="large">Large button</Button>
+```


### PR DESCRIPTION
Adds some logic to prevent rendering an "example" unless a `render` modifier is explicitly provided. Also adds tests to maintain test coverage with added code. 